### PR TITLE
Fix incorrect display issues.

### DIFF
--- a/WinPath.Tests/BackupCommandTests.cs
+++ b/WinPath.Tests/BackupCommandTests.cs
@@ -154,6 +154,17 @@ namespace WinPath.Tests
 
         [Fact]
         [SupportedOSPlatform("windows")]
+        public void CreateBackupWithoutUserAndSystemFlags()
+        {
+            Program.Main(new string[]
+            {
+                "backup",
+                "create"
+            });
+        }
+
+        [Fact]
+        [SupportedOSPlatform("windows")]
         public void CreateUserBackup()
         {
             Program.Main(

--- a/WinPath/src/Backup.cs
+++ b/WinPath/src/Backup.cs
@@ -66,7 +66,7 @@ namespace WinPath
             FileInfo[] reversedSystemList = systemDirFileInfo?.Reverse().ToArray();
 
             long temp; // For long.TryParse(..., out temp);
-            string seperator = "-----------------------------------------"; // Default seperator.
+            string separator = "-----------------------------------------"; // Default separator.
             string spaces = string.Empty; // The number of spaces between `Filename` and `|`.
 
             //var now = DateTime.Now;
@@ -75,9 +75,9 @@ namespace WinPath
 
             if (userDirFileInfo.Length > 0)
             {
-                seperator = string.Empty;
+                separator = string.Empty;
                 for (int i = 0; i < (userDirFileInfo[0].Name + " | " + DateTime.FromFileTime(long.Parse(userDirFileInfo[0].Name)).GetDateTimeFormats()[formatIndex]).Length; ++i)
-                    seperator += '-';
+                    separator += '-';
 
                 for (int i = 0; i < userDirFileInfo[0].Name.Length - "Filename".Length; ++i)
                     spaces += " ";
@@ -88,7 +88,7 @@ namespace WinPath
                 case HandleEventType.ListAllBackups:
                     Console.WriteLine("User Backups:");
                     Console.WriteLine("Filename" + spaces + " | Date of creation");
-                    Console.WriteLine(seperator);
+                    Console.WriteLine(separator);
 
                     foreach (FileInfo backupFile in userDirFileInfo)
                         Console.WriteLine(
@@ -104,11 +104,11 @@ namespace WinPath
                                   )
                         );
 
-                    Console.WriteLine(seperator + Console.Out.NewLine);
+                    Console.WriteLine(separator + Console.Out.NewLine);
 
                     Console.WriteLine("System Backups:");
                     Console.WriteLine("Filename | Date of creation");
-                    Console.WriteLine(seperator);
+                    Console.WriteLine(separator);
 
                     /*
                     if (systemDirFileInfo is not null)
@@ -129,7 +129,7 @@ namespace WinPath
                     }
                     else*/
                     Console.WriteLine("System backups not yet supported by the API.");
-                    Console.WriteLine(seperator);
+                    Console.WriteLine(separator);
                     break;
 
                 case HandleEventType.ListBackups:
@@ -145,7 +145,7 @@ namespace WinPath
                     {
                         Console.WriteLine("User Backups:");
                         Console.WriteLine("Filename" + spaces + " | Date of creation");
-                        Console.WriteLine(seperator);
+                        Console.WriteLine(separator);
 
                         for (int i = 0; i < range; ++i)
                         {
@@ -167,11 +167,11 @@ namespace WinPath
                             catch (IndexOutOfRangeException) { break; }
                         }
 
-                        Console.WriteLine(seperator + Console.Out.NewLine);
+                        Console.WriteLine(separator + Console.Out.NewLine);
 
                         Console.WriteLine("System Backups:");
                         Console.WriteLine("Filename | Date of creation");
-                        Console.WriteLine(seperator);
+                        Console.WriteLine(separator);
 
                         /*
                         if (reversedSystemList is not null)
@@ -197,7 +197,7 @@ namespace WinPath
                         else*/
                         Console.WriteLine("System backups not yet supported by the API.");
 
-                        Console.WriteLine(seperator);
+                        Console.WriteLine(separator);
                     }
                     break;
 

--- a/WinPath/src/Backup.cs
+++ b/WinPath/src/Backup.cs
@@ -39,6 +39,11 @@ namespace WinPath
             in int range = 3
         )
         {
+            // The value that defines the location of the desired format
+            // in the index of dateTimeObject.GetGetDateTimeFormats();.
+            // It strictly looks like: 01-Jan-20 12:00 PM.
+            const uint formatIndex = 12;
+
             DirectoryInfo userDirInfo = new DirectoryInfo(userBackupDirectory);
             DirectoryInfo systemDirInfo = systemBackupDirectory is null
                                             ? null
@@ -64,13 +69,15 @@ namespace WinPath
             string seperator = "-----------------------------------------"; // Default seperator.
             string spaces = string.Empty; // The number of spaces between `Filename` and `|`.
 
+            //var now = DateTime.Now;
+            //for (int i = 0; i < now.GetDateTimeFormats().Length; ++i)
+            //    Console.WriteLine(i + " " + now.GetDateTimeFormats()[i]);
+
             if (userDirFileInfo.Length > 0)
             {
                 seperator = string.Empty;
-                for (int i = -2; i < (userDirFileInfo[0].Name + " | " + long.Parse(userDirFileInfo[0].Name)).Length; ++i)
-                {
+                for (int i = 0; i < (userDirFileInfo[0].Name + " | " + DateTime.FromFileTime(long.Parse(userDirFileInfo[0].Name)).GetDateTimeFormats()[formatIndex]).Length; ++i)
                     seperator += '-';
-                }
 
                 for (int i = 0; i < userDirFileInfo[0].Name.Length - "Filename".Length; ++i)
                     spaces += " ";
@@ -92,7 +99,7 @@ namespace WinPath
                                         backupFile.Name,
                                         out temp
                                     )
-                                        ? DateTime.FromFileTime(temp)
+                                        ? DateTime.FromFileTime(temp).GetDateTimeFormats()[formatIndex]
                                         : "<Parsing error>"
                                   )
                         );
@@ -115,7 +122,7 @@ namespace WinPath
                                             backupFile.Name,
                                             out temp
                                         )
-                                            ? DateTime.FromFileTime(temp)
+                                            ? DateTime.FromFileTime(temp).GetDateTimeFormats()[formatIndex]
                                             : "<Parsing error>"
                                       )
                             );
@@ -152,7 +159,7 @@ namespace WinPath
                                                 reversedUserList[i].Name,
                                                 out temp
                                             )
-                                                ? DateTime.FromFileTime(temp)
+                                                ? DateTime.FromFileTime(temp).GetDateTimeFormats()[formatIndex]
                                                 : "<Parsing error>"
                                           )
                                 );
@@ -180,7 +187,7 @@ namespace WinPath
                                                     reversedSystemList[i].Name,
                                                     out temp
                                                 )
-                                                    ? DateTime.FromFileTime(temp)
+                                                    ? DateTime.FromFileTime(temp).GetDateTimeFormats()[formatIndex]
                                                     : "<Parsing error>"
                                               )
                                     );
@@ -215,6 +222,12 @@ namespace WinPath
             //    Console.WriteLine("Whoops, seems like there's an error on our end. Please use --user (-u) and --system (-s) flags before --directory (-d).");
             //    return;
             //}
+
+            if (!options.BackupUserVariables && !options.BackupSystemVariables)
+            {
+                Console.WriteLine("Did not modify any content because neither user or system flag is provided, exiting...");
+                return;
+            }
 
             // Invalid chars that may be in the provided directory.
             // For example:


### PR DESCRIPTION
This pull request fixes #52 balancing the list unlike when it does in v0.3.0.

The way this fixes it is by finding bad code, making improvements to how it prints out separators (`--------`) and calculating/setting the amount appropriately in respect to the first index and finally; printing a specific time format I found optimal for all situations; `01-Jan-20 12:00 PM`.

Unrelated fix: Fixed spelling mistake of `separator`, from `seperator`.